### PR TITLE
🔧💥 #15 Apply API breaking changes from Glide v0.0.4-rc.1

### DIFF
--- a/.github/workflows/activity-notifications.yaml
+++ b/.github/workflows/activity-notifications.yaml
@@ -1,7 +1,7 @@
 name: Pull Request Activity Notifications
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, closed, reopened]
 
 jobs:

--- a/examples/lang/chat_stream_async.py
+++ b/examples/lang/chat_stream_async.py
@@ -40,7 +40,7 @@ async def chat_stream() -> None:
                     continue
 
                 if err := message.error:
-                    print(f"💥ERR: {err.message} (code: {err.err_code})")
+                    print(f"💥ERR ({err.name}): {err.message}")
                     print("🧹 Restarting the stream")
                     continue
 
@@ -50,7 +50,7 @@ async def chat_stream() -> None:
 
         if last_msg and last_msg.chunk and last_msg.finish_reason:
             # LLM gen context
-            provider_name = last_msg.chunk.provider_name
+            provider_name = last_msg.chunk.provider_id
             model_name = last_msg.chunk.model_name
             finish_reason = last_msg.finish_reason
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ requires-python = ">=3.8"
 [project.urls]
 Homepage = "https://glide.einstack.ai/"
 Documentation = "https://glide.einstack.ai/"
-Repository = "https://github.com/me/spam.git"
-Issues = "https://github.com/EinStack/glide-python"
+Repository = "https://github.com/EinStack/glide-py.git"
+Issues = "https://github.com/EinStack/glide-py/issues/"
 
 [tool.pdm.version]
 source = "scm"

--- a/src/glide/exceptions.py
+++ b/src/glide/exceptions.py
@@ -29,7 +29,7 @@ class GlideChatStreamError(GlideError):
     Occurs when chat stream ends with an error
     """
 
-    def __init__(self, message: str, err_code: str) -> None:
+    def __init__(self, message: str, err_name: str) -> None:
         super().__init__(message)
 
-        self.err_code = err_code
+        self.err_name = err_name

--- a/src/glide/exceptions.py
+++ b/src/glide/exceptions.py
@@ -17,6 +17,22 @@ class GlideClientError(GlideError):
     Occurs when there is an issue with sending a Glide request
     """
 
+    def __init__(self, message: str, err_name: str) -> None:
+        super().__init__(message)
+
+        self.err_name = err_name
+
+
+class GlideServerError(GlideError):
+    """
+    Occurs when there is an issue with sending a Glide request related to Glide server issues
+    """
+
+    def __init__(self, message: str, err_name: str) -> None:
+        super().__init__(message)
+
+        self.err_name = err_name
+
 
 class GlideClientMismatch(GlideError):
     """

--- a/src/glide/lang/router_async.py
+++ b/src/glide/lang/router_async.py
@@ -82,8 +82,8 @@ class AsyncStreamChatClient:
                 if err := message.ended_with_err:
                     # fail only on fatal errors that indicate stream stop
                     raise GlideChatStreamError(
-                        f"Chat stream {req.id} ended with an error: {err.message} (code: {err.err_code})",
-                        err.err_code,
+                        f"Chat stream {req.id} ended with an error ({err.name}): {err.message}",
+                        err.name,
                     )
 
                 yield message  # returns content chunk and some error messages

--- a/src/glide/lang/router_async.py
+++ b/src/glide/lang/router_async.py
@@ -113,7 +113,7 @@ class AsyncStreamChatClient:
 
                 await self._ws_client.send(chat_request.json())
             except asyncio.CancelledError:
-                # TODO: log
+                logger.debug("chat stream sender task is canceled")
                 break
 
     async def _receiver(self) -> None:
@@ -136,6 +136,7 @@ class AsyncStreamChatClient:
                     exc_info=True,
                 )
             except asyncio.CancelledError:
+                logger.debug("chat stream receiver task is canceled")
                 break
             except Exception as e:
                 logger.exception(e)

--- a/src/glide/lang/schemas.py
+++ b/src/glide/lang/schemas.py
@@ -14,6 +14,11 @@ ChatRequestId = str
 Metadata = Dict[str, Any]
 
 
+class ChatError(Schema):
+    name: str
+    message: str
+
+
 class FinishReason(str, Enum):
     # generation is finished successfully without interruptions
     COMPLETE = "complete"

--- a/src/glide/lang/schemas.py
+++ b/src/glide/lang/schemas.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Dict, Any
 from pydantic import Field
 
 from glide.schames import Schema
-from glide.typing import RouterId, ProviderName, ModelName
+from glide.typing import RouterId, ProviderId, ModelName
 
 ChatRequestId = str
 Metadata = Dict[str, Any]
@@ -45,7 +45,7 @@ class ModelMessageOverride(Schema):
 class ChatRequest(Schema):
     message: ChatMessage
     message_history: List[ChatMessage] = Field(default_factory=list)
-    override: Optional[ModelMessageOverride] = None
+    override_params: Optional[ModelMessageOverride] = None
 
 
 class TokenUsage(Schema):
@@ -57,16 +57,16 @@ class TokenUsage(Schema):
 class ModelResponse(Schema):
     response_id: Dict[str, str]
     message: ChatMessage
-    token_count: TokenUsage
+    token_usage: TokenUsage
 
 
 class ChatResponse(Schema):
     id: ChatRequestId
-    created: datetime
-    provider: ProviderName
-    router: RouterId
+    created_at: datetime
+    provider_id: ProviderId
+    router_id: RouterId
     model_id: str
-    model: ModelName
+    model_name: ModelName
     model_response: ModelResponse
 
 
@@ -74,7 +74,7 @@ class ChatStreamRequest(Schema):
     id: ChatRequestId = Field(default_factory=lambda: str(uuid.uuid4()))
     message: ChatMessage
     message_history: List[ChatMessage] = Field(default_factory=list)
-    override: Optional[ModelMessageOverride] = None
+    override_params: Optional[ModelMessageOverride] = None
     metadata: Optional[Metadata] = None
 
 
@@ -90,7 +90,7 @@ class ChatStreamChunk(Schema):
 
     model_id: str
 
-    provider_name: ProviderName
+    provider_id: ProviderId
     model_name: ModelName
 
     model_response: ModelChunkResponse
@@ -99,7 +99,7 @@ class ChatStreamChunk(Schema):
 
 class ChatStreamError(Schema):
     id: ChatRequestId
-    err_code: str
+    name: str
     message: str
     finish_reason: Optional[FinishReason] = None
 

--- a/src/glide/lang/schemas.py
+++ b/src/glide/lang/schemas.py
@@ -55,7 +55,7 @@ class TokenUsage(Schema):
 
 
 class ModelResponse(Schema):
-    response_id: Dict[str, str]
+    metadata: Dict[str, str]
     message: ChatMessage
     token_usage: TokenUsage
 

--- a/src/glide/schames.py
+++ b/src/glide/schames.py
@@ -1,7 +1,6 @@
 # Copyright EinStack
 # SPDX-License-Identifier: APACHE-2.0
 from pydantic import BaseModel, ConfigDict
-from pydantic.alias_generators import to_camel
 
 
 class Schema(BaseModel):
@@ -10,7 +9,6 @@ class Schema(BaseModel):
     """
 
     model_config = ConfigDict(
-        alias_generator=to_camel,
         populate_by_name=True,
         from_attributes=True,
         protected_namespaces=(),

--- a/src/glide/typing.py
+++ b/src/glide/typing.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 RouterId = str
-ProviderName = str
+ProviderId = str
 ModelName = str


### PR DESCRIPTION
Applying breaking changes from https://github.com/EinStack/glide/pull/236:

- changed the request/response field name format to snake_case
- renamed router_id, model_name, provider_id fields
- introduced error name in the error responses

## Testing

![2024-05-13_14-18-00](https://github.com/EinStack/glide-py/assets/9402690/045958fe-6d39-41ca-a108-0db9e3f9900f)
